### PR TITLE
Fix duplicate push notifications: use data-only FCM payload

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -11,8 +11,8 @@ firebase.initializeApp({
 const messaging = firebase.messaging()
 
 messaging.onBackgroundMessage((payload) => {
-  self.registration.showNotification(payload.notification.title, {
-    body: payload.notification.body,
+  self.registration.showNotification(payload.data.title, {
+    body: payload.data.body,
     icon: '/partita-domani-a-roma/icons/android-chrome-192x192.png',
     data: { url: 'https://vlrprbttst.github.io/partita-domani-a-roma/' },
     tag:  'partita-domani-a-roma',

--- a/scripts/send-notifications.js
+++ b/scripts/send-notifications.js
@@ -74,10 +74,7 @@ const stale = []
 for (const chunk of chunks) {
   const response = await messaging.sendEachForMulticast({
     tokens: chunk,
-    notification: { title, body },
-    webpush: {
-      fcmOptions: { link: 'https://vlrprbttst.github.io/partita-domani-a-roma/' },
-    },
+    data: { title, body },
   })
   response.responses.forEach((r, i) => {
     if (!r.success && r.error?.code === 'messaging/registration-token-not-registered') stale.push(chunk[i])


### PR DESCRIPTION
## Summary
- A `notification` field at the FCM payload root made Chrome auto-display the message (favicon icon) while the service worker also rendered it via `onBackgroundMessage` (app icon), producing two simultaneous notifications per send.
- Switched to a data-only payload so only the SW shows the notification.

## Test plan
- [ ] After deploy, close/reopen PWA so the new SW activates
- [ ] Trigger `Send Match Notifications` workflow with `force_send: true`
- [ ] Verify a single notification arrives with the correct app icon

https://claude.ai/code/session_01K4WSWAJoWbRr4ZkyPs7YJ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4WSWAJoWbRr4ZkyPs7YJ5)_