### PR TITLE
Fix duplicate notifications via shared tag

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -11,8 +11,8 @@ firebase.initializeApp({
 const messaging = firebase.messaging()
 
 messaging.onBackgroundMessage((payload) => {
-  self.registration.showNotification(payload.data.title, {
-    body: payload.data.body,
+  self.registration.showNotification(payload.notification.title, {
+    body: payload.notification.body,
     icon: '/partita-domani-a-roma/icons/android-chrome-192x192.png',
     data: { url: 'https://vlrprbttst.github.io/partita-domani-a-roma/' },
     tag:  'partita-domani-a-roma',

--- a/scripts/send-notifications.js
+++ b/scripts/send-notifications.js
@@ -74,7 +74,11 @@ const stale = []
 for (const chunk of chunks) {
   const response = await messaging.sendEachForMulticast({
     tokens: chunk,
-    data: { title, body },
+    notification: { title, body },
+    webpush: {
+      notification: { tag: 'partita-domani-a-roma' },
+      fcmOptions: { link: 'https://vlrprbttst.github.io/partita-domani-a-roma/' },
+    },
   })
   response.responses.forEach((r, i) => {
     if (!r.success && r.error?.code === 'messaging/registration-token-not-registered') stale.push(chunk[i])


### PR DESCRIPTION
## Summary
- Previous fix used data-only FCM payload but messages weren't being delivered reliably to installed PWAs
- Restore `notification` field (so Chrome's auto-display always fires) and set `webpush.notification.tag` to match the SW tag
- Auto-display + SW notification now share the same tag → second collapses into first → user sees one notification with the correct app icon

## Test plan
- [ ] Wait for deploy to complete
- [ ] Reinstall PWA so the SW updates
- [ ] Trigger `Send Match Notifications` workflow with `force_send: true`
- [ ] Verify a single notification arrives

https://claude.ai/code/session_01K4WSWAJoWbRr4ZkyPs7YJ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4WSWAJoWbRr4ZkyPs7YJ5)_