### PR TITLE
Revert tag merge attempt; restore working notification payload

### DIFF
--- a/scripts/send-notifications.js
+++ b/scripts/send-notifications.js
@@ -76,7 +76,6 @@ for (const chunk of chunks) {
     tokens: chunk,
     notification: { title, body },
     webpush: {
-      notification: { tag: 'partita-domani-a-roma' },
       fcmOptions: { link: 'https://vlrprbttst.github.io/partita-domani-a-roma/' },
     },
   })


### PR DESCRIPTION
## Summary
- Revert the `webpush.notification.tag` change from PR #5
- Restore the exact pre-fix payload that was reliably delivering notifications (with duplicates)
- The duplicate-notifications issue remains, to be diagnosed separately

https://claude.ai/code/session_01K4WSWAJoWbRr4ZkyPs7YJ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4WSWAJoWbRr4ZkyPs7YJ5)_