### PR TITLE
Fix duplicate notifications: remove SW display, configure auto-display

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -10,15 +10,10 @@ firebase.initializeApp({
 
 const messaging = firebase.messaging()
 
-messaging.onBackgroundMessage((payload) => {
-  self.registration.showNotification(payload.notification.title, {
-    body: payload.notification.body,
-    icon: '/partita-domani-a-roma/icons/android-chrome-192x192.png',
-    data: { url: 'https://vlrprbttst.github.io/partita-domani-a-roma/' },
-    tag:  'partita-domani-a-roma',
-    renotify: true,
-  })
-})
+// FCM auto-displays the notification using webpush.notification config (set
+// in scripts/send-notifications.js). Calling showNotification here would
+// produce a second notification on top of the auto-display.
+messaging.onBackgroundMessage(() => {})
 
 self.addEventListener('notificationclick', (e) => {
   e.notification.close()

--- a/scripts/send-notifications.js
+++ b/scripts/send-notifications.js
@@ -76,6 +76,10 @@ for (const chunk of chunks) {
     tokens: chunk,
     notification: { title, body },
     webpush: {
+      notification: {
+        icon: '/partita-domani-a-roma/icons/android-chrome-192x192.png',
+        tag:  'partita-domani-a-roma',
+      },
       fcmOptions: { link: 'https://vlrprbttst.github.io/partita-domani-a-roma/' },
     },
   })


### PR DESCRIPTION
## Summary
- Root cause: with `notification` field in the FCM payload, Firebase web SDK auto-displays the notification AND fires `onBackgroundMessage`. The SW was calling `showNotification` in the callback, producing a second notification on top of the auto-display.
- Configure `icon` and `tag` in `webpush.notification` so the auto-display uses the correct app icon
- Turn `onBackgroundMessage` into a no-op so it no longer duplicates the display

## Test plan
- [ ] After deploy, reinstall PWA so the SW updates
- [ ] Trigger `Send Match Notifications` workflow with `force_send: true`
- [ ] Verify a single notification arrives with the correct app icon

https://claude.ai/code/session_01K4WSWAJoWbRr4ZkyPs7YJ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4WSWAJoWbRr4ZkyPs7YJ5)_